### PR TITLE
It's 2020.

### DIFF
--- a/nepdoc.html
+++ b/nepdoc.html
@@ -650,7 +650,7 @@ The
 booster is added automatically into the !freepacks system if you buy a
 jumbo booster that ends up having a disenchant value of exactly
 625&nbsp;points
-or (during the anniversary 2019 event:)
+or (during the anniversary 2019 and 2020 events)
 an anniversary booster of exactly 4000&nbsp;points
 before bounties.
 The
@@ -670,11 +670,10 @@ The
 <b>holiday</b>
 booster is a variant of the super booster that has slightly better odds
 and contained one more card.
-It was available during the holiday weeks of 2017 and is again available
-December&nbsp;1, 2018 to January&nbsp;14, 2019.
+It was available during the holiday weeks of every year since 2017.
 The Christmas versions had Ultra rarity during the event of 2017;
 they were changed to what is now called Promo after the event.
-It uses so-called event weightings, which makes it drop the
+The holiday booster uses so-called event weightings, which makes it drop the
 Christmas/Winter versions of some cards more frequently.
 They guarantee four Rare cards; no card is below Uncommon.
 The
@@ -711,6 +710,8 @@ During the anniversary event, the
 booster is a booster pack with 7&nbsp;cards with odds that are comparable to
 those of a premium booster but with bias towards Legendaries in particular,
 costing 4000&nbsp;points.
+The Legendary bias increases its chances to drop Promos before promotion,
+as normally there are Promos launched alongside the anniversary event.
 They have a highly boosted chance for event tokens.
 </p>
 <p id="p49"><span class="pn"><a href="#p49">[49]</a></span>
@@ -992,9 +993,8 @@ considered too rigid for scaling the rewards.
 Furthermore, a lot of sets were claimed very fast for the purpose of
 making a profit, which was seen as undesirable.
 A secondary currency just happened to be the most efficient way to
-resolve both of these problems.
-Sets don't exist anymore, so the only justification are historical
-reasons now.
+resolve both of these problems,
+introduced the July 2018 update.
 </p>
 </aside>
 <h3 id="!pudding">Checking your pudding balance (!pudding)</h3>
@@ -1077,33 +1077,13 @@ If 1000&nbsp;points or more are successfully transferred,
 the recipient receives a whisper about the transaction.
 </p>
 <p id="p95"><span class="pn"><a href="#p95">[95]</a></span>
-Please make sure you are actively aware of the rules around points transfers
-before trying to use them:
+Please make sure you are actively aware of the
+<a href="https://waifus.de/rules#collapseOne_the-basics">rules</a>
+around points transfers before trying to use them.
 </p>
-<ol>
-  <li><b>list of acceptable reasons</b> (non-exhaustive):
-    <ol>
-      <li>paying above the disenchant price for a highly demanded card;</li>
-      <li>paying below the disenchant price for an unwanted card;</li>
-      <li><em>temporary</em> loans of up to three&nbsp;months;</li>
-      <li>renting hand space (this does not change the policy that the
-      current owner of a card is considered the owner for the purpose of
-      trading the card otherwise).</li>
-    </ol>
-  </li>
-  <li><b>list of unacceptable reasons</b> (non-exhaustive):
-    <ol>
-      <li>giveaways, even when quitting the game;</li>
-      <li>moving points off of alternate accounts (since alternate accounts themselves are prohibited);</li>
-      <li>compensation for any event/transfer outside the game,
-        in particular real money trade (&ldquo;RMT&rdquo;).</li>
-    </ol>
-  </li>
-</ol>
-<!-- TODO <div class="dead"> -->
 <h2 id="anniversary-2019-cmds">Event token commands</h2>
 <p id="p95a"><span class="pn"><a href="#p95a">[95a]</a></span>
-During the 2019 anniversary event, event tokens can be obtained.
+During the 2019 and 2020 anniversary events, event tokens can be obtained.
 This section describes the commands available to make use of them
 (the &ldquo;token shop&rdquo;).
 </p>
@@ -1168,7 +1148,7 @@ selection and image choice apply.
 In particular, this means that you may not have
 an excessively lewd image,
 an excessively low-quality image,
-a original characters/fursonas,
+original characters/fursonas,
 male characters or
 novelty cards that do not depict a character at all.
 You <em>may have two characters</em> on the card.
@@ -1182,10 +1162,10 @@ See <i>mutatis mutandis</i> <a href="#p153">&para;&nbsp;153</a> for details and 
 Any leftover tokens that you cannot or do not want to turn into the prizes
 mentioned above can be rolled on the tokenshop gacha.
 Failure to do so manually will cause the tokens to be forcibly fed into the
-gacha on 2019-09-08 at 00:00&nbsp;UTC.
+gacha on 2019-09-17 at 00:00.
 </p>
 <p id="p95n"><span class="pn"><a href="#p95n">[95n]</a></span>
-The gacha rewards were divided into five tiers.
+The gacha rewards are divided into five tiers.
 First, the tier is picked.
 After that, a reward is picked from the tier.
 When rolling the gacha with !tokengacha,
@@ -1200,7 +1180,6 @@ you could thus get:
   <tr><td>5</td><td>ultimate booster pack, 200 pudding, 4000 points, freelegendary</td></tr>
   <tr><td>6</td><td>jumbultimate booster pack, 20,000 points, freemythical + 5000 points</td></tr>
 </table>
-<!-- TODO </div> --> <!-- class=dead -->
 <h2 id="betting">Betting</h2>
 <p id="p96"><span class="pn"><a href="#p96">[96]</a></span>
 The bet system allows streamers to host betting contests for their
@@ -1513,6 +1492,7 @@ Known public redeem codes are:
   <tr><td>1-800-tcg-waifu</td><td>1000&nbsp;points</td></tr>
   <tr><td>50kusers</td><td>1000&nbsp;points</td></tr>
   <tr><td>blazinghard</td><td>the Blazed Hard badge</td></tr>
+  <tr><td>chopchopchop</td><td>the TIMBER badge</td></tr>
   <tr><td>freescam</td><td>a scam booster pack</td></tr>
   <tr><td>memes</td><td>10&nbsp;points</td></tr>
   <tr><td>newcomerpack</td><td>250&nbsp;points and a standard booster</td></tr>
@@ -1561,7 +1541,7 @@ or
 <p id="p128"><span class="pn"><a href="#p128">[128]</a></span>
 !disenchant disenchants cards.
 If you have multiple of the same card, this command will disenchant only
-as many cards as specified; that is, &ldquo;!de 1984&rdquo; disenchants one of 1984,
+as many cards as specified; that is, <kbd>!de 1984</kbd> disenchants one of 1984,
 even if there are multiple in your hand.
 When disenchanting a card of Mythical rarity or above, or a promoted card, a
 confirmation prompt will be shown.
@@ -1578,9 +1558,9 @@ very end of the list.
 </p>
 <p id="p130"><span class="pn"><a href="#p130">[130]</a></span>
 For example, if you have only one card for a given waifu
-(e.g. waifu ID&nbsp;1984), &ldquo;!de 1984&rdquo; will disenchant that.
+(e.g. waifu ID&nbsp;1984), <kbd>!de 1984</kbd> will disenchant that.
 If you instead have 2&nbsp;cards of the same ID, you will have to specify the <i>card ID</i>
-(e.g. card ID&nbsp;1012123) like so: &ldquo;!de 1012123&rdquo;.
+(e.g. card ID&nbsp;1012123) like so: <kbd>!de 1012123</kbd>.
 </p>
 <h3 id="!nepleave">Making the bot leave your channel (!nepleave)</h3>
 <p id="p131"><span class="pn"><a href="#p131">[131]</a></span>
@@ -1630,7 +1610,7 @@ Issues that warrant a fix include:
 </p>
 <p id="p139"><span class="pn"><a href="#p139">[139]</a></span>
 This command just gets the reply &ldquo;No.&rdquo; from the bot.
-!giveme used to instead yield &ldquo;Sorry, you are not an admin.&rdquo;
+<kbd>!giveme</kbd> used to instead yield &ldquo;Sorry, you are not an admin.&rdquo;
 Originally, the command dropped a card of the requested rarity.
 It was used to test the drop/rarity algorithm.
 </p>
@@ -1650,6 +1630,10 @@ Sort numbers can be in the range of -32768 to 32767.
 Cards that have no sort number explicitly set will have a sort number of 32000,
 and the waifu IDs and rarity card IDs act as tie breakers in that case.
 (It's probably easier to actually fiddle around with it to understand how it works.)
+</p>
+<p id="p141a"><span class="pn"><a href="#p141a">[141a]</a></span>
+You can use the &ldquo;Sorthand command generator&rdquo; linked on the hand page
+to generate the command for you using simple sequential ordering.
 </p>
 <h3 id="!sorthand-reset">Resetting your hand sorting (!sorthand reset)</h3>
 <p id="p142"><span class="pn"><a href="#p142">[142]</a></span>
@@ -1677,8 +1661,12 @@ reasons of readability:
 </p>
 <table>
   <tr><th>Badge</th><th>Awarded for</th><th>Unique</th></tr>
+  <tr><td>2nd Year Nepiversary</td><td>redeem code (during the anniversary event of 2019)</td><td>no</td></tr>
+  <tr><td>2rd Anniversary</td><td>redeem code (during the anniversary event of 2020)</td><td>no</td></tr>
   <tr><td>2018</td><td>redeem code (valid for 20&nbsp;min. on 2018-01-01)</td><td>no</td></tr>
-  <tr><td>2019</td><td>redeem code (&ldquo;OnwardsTo2019&rdquo;) (valid for 1&nbsp;hour on 2019-01-01)</td><td>no</td></tr>
+  <tr><td>2018</td><td>redeem code (valid for 20&nbsp;min. on 2018-01-01)</td><td>no</td></tr>
+  <tr><td>2019</td><td>redeem code (&ldquo;OnwardsTo2019&rdquo;) (valid for one&nbsp;hour on 2019-01-01)</td><td>no</td></tr>
+  <tr><td>2020</td><td>redeem code (&ldquo;HeyAll2020Here&rdquo;) (valid for one&nbsp;hour on 2020-01-01)</td><td>no</td></tr>
   <tr><td>Beta Participant</td><td>active in the earliest days of the bot</td><td>no</td></tr>
   <tr><td>Blazed Hard</td><td>redeem code (&ldquo;BlazingHard&rdquo;)</td><td>no</td></tr>
   <tr><td>Brave New World</td><td>automatically awarded to players active before the July 2019 update</td><td>no</td></tr>
@@ -1688,6 +1676,7 @@ reasons of readability:
   <tr><td>Fixer</td><td>submitting an accepted fix for a waifu via https://waifus.de/fixes</td><td>no</td></tr>
   <tr><td>Glimmer of Hope</td><td>Being down in the dumps</td><td>yes (MattyPlaysSRL)</td></tr>
   <tr><td>HASHIRE SORI YO KAZE NO YOU NI TSUKIMIHARA WO PADORU PADORU</td><td>redeem code (&ldquo;XMAS-TCG-2018&rdquo;) (2018-12-24 through 2018-12-26)</td><td>no</td></tr>
+  <tr><td>Padoru 2019-1</td><td>redeem code (holiday season of 2019)</td><td>no</td></tr>
   <tr><td>Miku's Mercy</td><td>meeting an administrator in real life</td><td>no</td></tr>
   <tr><td>NOT a Bot admin</td><td>clarifying that user is not an administrator</td><td>yes (xorhash)</td></tr>
   <tr><td>OUR Community</td><td>meeting any TCG player in real life</td><td>no</td></tr>
@@ -1698,6 +1687,7 @@ reasons of readability:
   <tr><td>The Listener</td><td>redeem code (ARG)</td><td>no</td></tr>
   <tr><td>The Midway Point</td><td>redeem code (ARG)</td><td>no</td></tr>
   <tr><td>The second one</td><td>redeem code (ARG)</td><td>no</td></tr>
+  <tr><td>TIMBER</td><td>redeem code</td><td>no</td></tr>
 </table>
 <h3 id="!profile-description">Setting a profile description (!profile description)</h3>
 <p id="p146"><span class="pn"><a href="#p146">[146]</a></span>
@@ -1747,6 +1737,7 @@ The image change can be either individual or global.
 -->
 </p>
 <p id="p153"><span class="pn"><a href="#p153">[153]</a></span>
+<!-- XXX this should be on /rules instead -->
 The following
 <b>
 base requirements
@@ -1873,7 +1864,7 @@ Note that a JSON API for the same data is available on
   https://waifus.de/pullfeed</a>.
 You could use this to make your own alerts for other streaming software.
 If you have some programming knowledge,
-consult the source code for details.
+consult the <a href="https://github.com/Marenthyu/NepBot">source code</a> for details.
 </p>
 </aside>
 <p id="p163"><span class="pn"><a href="#p163">[163]</a></span>
@@ -2044,11 +2035,12 @@ the Streamlabs dashboard.
 If set to &ldquo;rarity&rdquo;, the rarity and name of the player who pulled the
 card in the alert to be the rarity's representative color instead.
 If you have never changed this setting, it is set to &ldquo;default&rdquo;.
-<div class="dead">
-<h1 id="anniversary-2019">The 2019 anniversary event</h1>
+<h1 id="anniversary-2019">The 2019 and 2020 anniversary events</h1>
 <p id="p182a"><span class="pn"><a href="#p182a">[182a]</a></span>
-During August 1, 2019 and August 31, 2019 (UTC),
-the 2019 anniversary event takes place.
+During August 12, 2020 through September 17, 2020,
+the yearly anniversary event takes place,
+effectively a carbon copy of last year's during August 1, 2019 and
+August 31, 2019 (UTC).
 During the event, so-called <b>event tokens</b> can be acquired.
 Event tokens can be exchanged for various special rewards.
 </p>
@@ -2074,7 +2066,6 @@ Event tokens show up in your hand, but take no hand space.
 They cannot be disenchanted.
 Similarly, they are not transferable or tradeable.
 </p>
-</div> <!-- class=dead TODO move past 182e -->
 <p id="p182e"><span class="pn"><a href="#p182e">[182e]</a></span>
 The following rewards in exchange for tokens are available:
 </p>
@@ -2155,15 +2146,17 @@ These cards are unique.
 </p>
 <p id="p190"><span class="pn"><a href="#p190">[190]</a></span>
 They used to be given out to cornerstones of the community.
-Those are marked as &ldquo;special thanks&rdquo;.
-However, &ldquo;special thanks&rdquo; Special cards no longer occur.
-Similarly, high amounts of dedication to a franchise could sometimes
+However, such &ldquo;special thanks&rdquo; Special cards no longer occur.
+Similarly, high amounts of dedication to a franchise used to sometimes
 yield a Special card.
 However, requirements have spiked lately:
 Only truly extraordinary achievements &ndash; such as amassing
 one&nbsp;million&nbsp;points &ndash; still award a Special card these days.
-Some cards were given out as reference to some in-joke;
-those are marked with &ldquo;(meme)&rdquo;.
+</p>
+<p id="p190a"><span class="pn"><a href="#p190a">[190a]</a></span>
+The most common source of Special cards are the anniversary events of
+2019 and 2020, where a Special of one's choosing could be obtained in
+exchange for 25&nbsp;anniversary tokens.
 </p>
 <p id="p191"><span class="pn"><a href="#p191">[191]</a></span>
 Anyone can get a Special card by sending a postcard to Marenthyu or
@@ -2171,6 +2164,7 @@ meeting up with him.
 Sending a postcard allows the sender to pick a custom name and image,
 but the series will be locked to &ldquo;Postcard Collector&rdquo;.
 Meeting up with Marenthyu will yield a &ldquo;The Truth&rdquo; card.
+</p>
 <h1 id="pulling-algorithm">Pulling algorithm</h1>
 <p id="p192"><span class="pn"><a href="#p192">[192]</a></span>
 This section outlines the algorithm that guards what cards are pulled
@@ -2307,7 +2301,7 @@ Waifu TCG.
 Participation will yield Special cards and badges.
 Further details about joining and the current state of the ARG can be
 found at
-<a href="https://xorhash.bitbucket.io/nepbot/arg/">my page about the ARG</a>.
+<a href="https://xorhash.bitbucket.io/nepbot/arg/">xorhash's page about the ARG</a>.
 </p>
 <p id="p203"><span class="pn"><a href="#p203">[203]</a></span>
 The ARG is an <em>optional</em> part of the Waifu TCG experience.

--- a/nepdoc.html
+++ b/nepdoc.html
@@ -994,7 +994,7 @@ Furthermore, a lot of sets were claimed very fast for the purpose of
 making a profit, which was seen as undesirable.
 A secondary currency just happened to be the most efficient way to
 resolve both of these problems,
-introduced the July 2018 update.
+introduced in the July 2018 update.
 </p>
 </aside>
 <h3 id="!pudding">Checking your pudding balance (!pudding)</h3>
@@ -1662,8 +1662,7 @@ reasons of readability:
 <table>
   <tr><th>Badge</th><th>Awarded for</th><th>Unique</th></tr>
   <tr><td>2nd Year Nepiversary</td><td>redeem code (during the anniversary event of 2019)</td><td>no</td></tr>
-  <tr><td>2rd Anniversary</td><td>redeem code (during the anniversary event of 2020)</td><td>no</td></tr>
-  <tr><td>2018</td><td>redeem code (valid for 20&nbsp;min. on 2018-01-01)</td><td>no</td></tr>
+  <tr><td>3rd Anniversary</td><td>redeem code (during the anniversary event of 2020)</td><td>no</td></tr>
   <tr><td>2018</td><td>redeem code (valid for 20&nbsp;min. on 2018-01-01)</td><td>no</td></tr>
   <tr><td>2019</td><td>redeem code (&ldquo;OnwardsTo2019&rdquo;) (valid for one&nbsp;hour on 2019-01-01)</td><td>no</td></tr>
   <tr><td>2020</td><td>redeem code (&ldquo;HeyAll2020Here&rdquo;) (valid for one&nbsp;hour on 2020-01-01)</td><td>no</td></tr>


### PR DESCRIPTION
Various changes since the doc had been left alone for a while.
Many open issues probably remain, but these are just the low-hanging
fruit.

- 2020 is essentially a no-budget rerun of the 2019 anniversary event;
  note this in the relevant places.
- holiday is a staple now, stop pretending it's an unusual circumstance.
- Explain why annipacks have Legendary bias.
- Be more precise about when bet rewards "used to be" packs because
  it's been a bloody long time.
- Remove sendpoints rules now that a /rules page exists.
  Does not resolve the issue for the Specials and godimages though
  (add a snark about that).
- Remove timezone info on when anniversary 2020 ends because the
  upstream pastebin only mentions the timezone for the starting, but
  not the ending time.
- Add chopchopchop redeemable token.
- Update list of badges.
- Remove text that referred to the long-removed list of Specials
  (which was removed because of the annipack-fueled inflation of
  Specials, but that doesn't need to be noted there).
- Note the existence of the sorthand command generator.
- Remove references to "me" since I'm only the original author now.
- Minor grammar and formatting fixes to enhance the user experience.

nav.sh/ts.sh not executed because deploy.sh does it for me.